### PR TITLE
Add decoders for CGlobalSymbol and CUtlBinaryBlock (fixes #10)

### DIFF
--- a/source2-demo/src/display.rs
+++ b/source2-demo/src/display.rs
@@ -204,6 +204,7 @@ impl Display for FieldDecoder {
         let output = match &self {
             FieldDecoder::Boolean => "bool",
             FieldDecoder::String => "String",
+            FieldDecoder::BinaryBlock => "String",
             FieldDecoder::Signed8 => "i32",
             FieldDecoder::Signed16 => "i16",
             FieldDecoder::Signed32 => "i32",

--- a/source2-demo/src/entity/field/decoder.rs
+++ b/source2-demo/src/entity/field/decoder.rs
@@ -8,6 +8,7 @@ pub(crate) trait Decode {
 pub(crate) enum FieldDecoder {
     Boolean,
     String,
+    BinaryBlock,
     Signed8,
     Signed16,
     Signed32,
@@ -33,7 +34,9 @@ impl FieldDecoder {
                 FieldDecoder::Boolean
             }
 
-            "char" | "CUtlString" | "CUtlSymbolLarge" => FieldDecoder::String,
+            "char" | "CUtlString" | "CUtlSymbolLarge" | "CGlobalSymbol" => FieldDecoder::String,
+
+            "CUtlBinaryBlock" => FieldDecoder::BinaryBlock,
 
             "Vector" | "VectorWS" => FieldDecoder::Vector(VectorDecoder {
                 properties,
@@ -80,6 +83,11 @@ impl FieldDecoder {
                 reader.read_bool()
             }),
             FieldDecoder::String => FieldValue::String(reader.read_cstring()),
+            FieldDecoder::BinaryBlock => FieldValue::String({
+                let n = reader.read_var_u32();
+                let bytes = reader.read_bytes(n);
+                String::from_utf8_lossy(&bytes).into_owned()
+            }),
 
             FieldDecoder::Signed8 => FieldValue::Signed8(reader.read_var_i32() as i8),
             FieldDecoder::Signed16 => FieldValue::Signed16(reader.read_var_i32() as i16),


### PR DESCRIPTION
## Summary

Adds `FieldDecoder` support for two base types that the 2026-04-21 CS2 update introduced into the flattened-serializer table:

- **`CGlobalSymbol`** — null-terminated string (same wire format as `CUtlSymbolLarge` / `CUtlString`).
- **`CUtlBinaryBlock`** — varint length prefix followed by that many raw bytes; decoded to a `String` via `from_utf8_lossy` to match existing handling of binary-typed strings elsewhere in the crate.

Without these decoders, `from_field` falls through to the default `Unsigned32` arm. `Unsigned32` consumes a `varuint32` from the bit stream, which is the wrong width for either of the two new types, so the first time such a field appears in an entity update the `BitsReader` misaligns and every subsequent `cmd` read is garbage. In practice that surfaces as a spurious `cmd=0` (Updated) on an uninitialized entity slot and a panic inside `Serializer::get_decoder_for_field_path` at `entity/field/serializer.rs:117` with *"index out of bounds: the len is 0 but the index is 0"* — matching #10 exactly.

## Relationship to #10

Issue #10 describes the downstream symptom precisely and correctly identifies that a `Serializer` with empty `fields` is being walked at read time. My investigation pointed at a different *cause*: the serializer itself is built correctly; it's the **bit reader going out of sync** earlier in the same packet that eventually drives `cmd=0` reads into uninitialized slots. Fixing the decoders keeps the reader aligned, the symptom disappears, and no changes to the serializer-construction logic are needed.

## Verification

Verified against three CS2 demo files:

1. **Post-2026-04-21 demo** (the one that triggered the panic before this patch) — parses cleanly, 360 grenade trajectories extracted.
2. **MongolZ vs ParaVision, Mirage m2** (pre-update reference, 21 rounds, regulation) — scoreline unchanged: CT=11, T=10, CT winner, no OT.
3. **Vitality vs Falcons, Nuke m3** (pre-update reference, 30 rounds, OT) — scoreline unchanged: CT=21, T=9, CT winner, `is_overtime=true`.

All existing tests pass: 25 unit tests + 2 fixture-backed integration tests (`round_tracking.rs`).

## Sources

This fix was produced during a systematic debugging session by [Claude Code](https://claude.com/claude-code) (Anthropic's Claude Opus 4.7). The full root-cause analysis and step-by-step procedure is in the commit message. The decoder shape was cross-checked against two other Source 2 parsers that shipped the same-day fix:

- **[LaihoE/demoparser@410951de6f](https://github.com/LaihoE/demoparser/commit/410951de6f)** — *"Support Anim Graph 2 demos (CGlobalSymbol + CUtlBinaryBlock) (#322)"*, 2026-04-21. Rust CS2 parser; supplied the `BinaryBlockDecoder` reference.
- **[markus-wa/demoinfocs-golang@696210ba10](https://github.com/markus-wa/demoinfocs-golang/commit/696210ba10)** — *"fix: decode CGlobalSymbol as null-terminated string"*, 2026-04-21. Independent Go parser fix naming the same type.

Both land the same pair of type mappings, which gave me high confidence that the CS2 change is exactly these two types and nothing else.

## Diff

Two files, 10 insertions, 1 deletion:

- `source2-demo/src/entity/field/decoder.rs` — add `FieldDecoder::BinaryBlock` variant, add `CGlobalSymbol` to the string-type arm, add `CUtlBinaryBlock` → `BinaryBlock` mapping, implement `decode` for the new variant.
- `source2-demo/src/display.rs` — extend `Display for FieldDecoder` to keep the match exhaustive.

Fixes #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)